### PR TITLE
use custom runTask

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,8 @@ import { TasksProvider, TaskItem } from './tasksProvider';
 const COMMANDS = {
     refreshTasks: 'fast-tasks.refreshTasks',
     selectTasks: 'fast-tasks.selectTasks',
-    stopTask: 'fast-tasks.stopTask'
+    stopTask: 'fast-tasks.stopTask',
+    runTask: 'fast-tasks.runTask'
 } as const;
 
 export function activate(context: vscode.ExtensionContext): void {
@@ -34,6 +35,10 @@ function registerCommands(tasksProvider: TasksProvider): vscode.Disposable[] {
         vscode.commands.registerCommand(
             COMMANDS.stopTask, 
             (item: TaskItem) => tasksProvider.stopTask(item)
+        ),
+        vscode.commands.registerCommand(
+            COMMANDS.runTask, 
+            (task: vscode.Task) => vscode.tasks.executeTask(task)
         )
     ];
 }

--- a/src/tasksProvider.ts
+++ b/src/tasksProvider.ts
@@ -159,9 +159,9 @@ export class TasksProvider implements vscode.TreeDataProvider<TaskItem> {
             task.definition.type,
             vscode.TreeItemCollapsibleState.None,
             {
-                command: 'workbench.action.tasks.runTask',
+                command: 'fast-tasks.runTask',
                 title: '',
-                arguments: [task.name]
+                arguments: [task]
             },
             task
         );
@@ -202,8 +202,8 @@ export class TaskItem extends vscode.TreeItem {
         public readonly label: string,
         public readonly taskType: string,
         public readonly collapsibleState: vscode.TreeItemCollapsibleState,
-        public readonly command?: vscode.Command,
-        private readonly task?: vscode.Task
+        public readonly command: vscode.Command,
+        public readonly task: vscode.Task
     ) {
         super(label, collapsibleState);
         


### PR DESCRIPTION
I had tasks called 'compile' and 'compile-web', and workbench.action.tasks.runTask would bring up its selector for me to differentiate between them...
So I made a small tweak to your code to call vscode.tasks.executeTask(task) directly