### PR TITLE
Added: Support for Comments in tasks.json

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -32,6 +32,7 @@ async function main() {
 		entryPoints: [
 			'src/extension.ts'
 		],
+		mainFields: ["module", "main"],
 		bundle: true,
 		format: 'cjs',
 		minify: production,

--- a/package.json
+++ b/package.json
@@ -110,5 +110,8 @@
     "eslint": "^8.56.0",
     "npm-run-all": "^4.1.5",
     "typescript": "^5.6.3"
+  },
+  "dependencies": {
+    "jsonc-parser": "^3.3.1"
   }
 }

--- a/src/tasksProvider.ts
+++ b/src/tasksProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
+import * as JSONC from 'jsonc-parser';
 
 interface TaskStatus {
     isActive: boolean;
@@ -123,7 +124,7 @@ export class TasksProvider implements vscode.TreeDataProvider<TaskItem> {
     private loadIconsFromTasksFile(filePath: string): void {
         try {
             const content = fs.readFileSync(filePath, 'utf8');
-            const tasksConfig = JSON.parse(content);
+            const tasksConfig = JSONC.parse(content);
             
             // Get the workspace folder this tasks.json belongs to
             const workspaceFolder = vscode.workspace.workspaceFolders?.find(folder => 


### PR DESCRIPTION
### JSONC support:
* `package.json`: Added [`jsonc-parser`](https://www.npmjs.com/package/jsonc-parser) library.
* `src/tasksProvider.ts`: Imported `jsonc-parser` and replaced `JSON.parse` with `JSONC.parse` in the `loadIconsFromTasksFile` method to handle VSCodes acceptance of comments in `tasks.json`

### Build process:
* `esbuild.js`: Updated the build configuration to include `mainFields` with values `["module", "main"]` to handle `jsonc-parser`s UMD.
    * See [microsoft/node-jsonc-parser#57](https://github.com/microsoft/node-jsonc-parser/issues/57) and [evanw/esbuild#1619](https://github.com/evanw/esbuild/issues/1619)
