### PR TITLE
Add edit task context action

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,11 @@
         "command": "fast-tasks.stopTask",
         "title": "Stop Task",
         "icon": "$(stop)"
+      },
+      {
+        "command": "fast-tasks.editTask",
+        "title": "Edit Task",
+        "icon": "$(edit)"
       }
     ],
     "views": {
@@ -77,6 +82,11 @@
         {
           "command": "fast-tasks.stopTask",
           "when": "view == fastTasksView && viewItem == runningTask",
+          "group": "inline"
+        },
+        {
+          "command": "fast-tasks.editTask",
+          "when": "view == fastTasksView && viewItem == task",
           "group": "inline"
         }
       ]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,8 @@ import { TasksProvider, TaskItem } from './tasksProvider';
 const COMMANDS = {
     refreshTasks: 'fast-tasks.refreshTasks',
     selectTasks: 'fast-tasks.selectTasks',
-    stopTask: 'fast-tasks.stopTask'
+    stopTask: 'fast-tasks.stopTask',
+    editTask: 'fast-tasks.editTask'
 } as const;
 
 export function activate(context: vscode.ExtensionContext): void {
@@ -32,8 +33,12 @@ function registerCommands(tasksProvider: TasksProvider): vscode.Disposable[] {
             () => tasksProvider.selectTasks()
         ),
         vscode.commands.registerCommand(
-            COMMANDS.stopTask, 
+            COMMANDS.stopTask,
             (item: TaskItem) => tasksProvider.stopTask(item)
+        ),
+        vscode.commands.registerCommand(
+            COMMANDS.editTask,
+            (item: TaskItem) => tasksProvider.editTask(item)
         )
     ];
 }


### PR DESCRIPTION
## Summary
- add `fast-tasks.editTask` command
- open tasks.json at line of selected task
- expose command in explorer context menu

## Testing
- `npm test` *(fails: Failed to parse response from https://update.code.visualstudio.com/api/releases/stable?released=true)*

------
https://chatgpt.com/codex/tasks/task_e_684250d2dfc083299246bbd0024ef090