### PR TITLE
Fix: show workspace-scoped tasks in multi-folder .code-workspace grouped mode

### DIFF
--- a/src/tasksProvider.ts
+++ b/src/tasksProvider.ts
@@ -360,13 +360,17 @@ export class TasksProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
 
         // Grouped mode
         if (!element) {
+            const workspaceScopedTasks = tasks.filter(task => typeof task.scope === 'number');
             const foldersWithTasks = vscode.workspace.workspaceFolders.filter(folder =>
                 tasks.some(task => {
                     const scope = task.scope as vscode.WorkspaceFolder;
                     return scope?.name === folder.name;
                 })
             );
-            return foldersWithTasks.map(folder => new WorkspaceItem(folder));
+            return [
+                ...workspaceScopedTasks.map(task => this.createTaskItem(task)),
+                ...foldersWithTasks.map(folder => new WorkspaceItem(folder)),
+            ];
         }
 
         if (element instanceof WorkspaceItem) {


### PR DESCRIPTION
ISSUE: https://github.com/Batyan45/fast-tasks/issues/16

In a multi-root workspace with multiple folders, the task panel grouped mode would not display tasks defined in the root 'tasks' section of the .code-workspace file. This happened because:

1. Tasks from .code-workspace root have scope=vscode.TaskScope.Workspace (numeric)
2. Folder-level tasks have scope as WorkspaceFolder (object)
3. The grouping logic only matched WorkspaceFolder scopes to folder names
4. Workspace-scoped tasks were silently dropped from the tree

Fix: In grouped mode, separate workspace-scoped tasks (numeric scope) from folder-scoped tasks, and display workspace tasks at the root level before folder groups.

This ensures:
- Tasks from .code-workspace root appear at top level in multi-folder workspaces
- Folder-level tasks still appear grouped under their respective folders
- Single-folder workspaces continue using flat mode (unaffected)